### PR TITLE
feat: add gh/workflows with golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -17,5 +17,3 @@ jobs:
         run: go test ./...
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
-        with:
-          go-version-file: 'go.mod'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,17 +15,7 @@ jobs:
         run: go get .
       - name: Test with the Go CLI
         run: go test ./...
-
-  golangci:
-      name: lint
-      runs-on: ubuntu-latest
-      steps:
-        - uses: actions/checkout@v4
-        - uses: actions/setup-go@v5
-          with:
-            go-version-file: 'go.mod'
-        - name: golangci-lint
-          uses: golangci/golangci-lint-action@v6
-          with:
-            version: v1.59
-      
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          go-version-file: 'go.mod'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,31 @@
+name: Go
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Install dependencies
+        run: go get .
+      - name: Test with the Go CLI
+        run: go test ./...
+
+  golangci:
+      name: lint
+      runs-on: ubuntu-latest
+      steps:
+        - uses: actions/checkout@v4
+        - uses: actions/setup-go@v5
+          with:
+            go-version: stable
+        - name: golangci-lint
+          uses: golangci/golangci-lint-action@v6
+          with:
+            version: v1.59
+      

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -23,7 +23,7 @@ jobs:
         - uses: actions/checkout@v4
         - uses: actions/setup-go@v5
           with:
-            go-version: stable
+            go-version-file: 'go.mod'
         - name: golangci-lint
           uses: golangci/golangci-lint-action@v6
           with:

--- a/.prar.json
+++ b/.prar.json
@@ -1,0 +1,1 @@
+{"prar": ["claudionts","joaothallis"]}


### PR DESCRIPTION
The golang linter using is [golangci-lint](https://golangci-lint.run/welcome/quick-start/), and will implementation with [golangci-lint-action](https://github.com/golangci/golangci-lint-action).

Closes #3 